### PR TITLE
Removing constructor arguments that caused an error during compilation.

### DIFF
--- a/Block/Html/Topmega.php
+++ b/Block/Html/Topmega.php
@@ -114,7 +114,7 @@ class Topmega extends Topmenu
         $this->categoryHelper = $categoryHelper;
         $this->extraClass = '';
         $this->menuType = 'default';
-        $this->currentStore = $this->storeManager->getStore();
+        $this->currentStore = $this->_storeManager->getStore();
         $this->mediaUrl = $this->currentStore->getBaseUrl(\Magento\Framework\UrlInterface::URL_TYPE_MEDIA);
         $this->categoryMediaUrl = $this->mediaUrl."catalog/category/";
         $this->parentId = false;

--- a/Block/Html/Topmega.php
+++ b/Block/Html/Topmega.php
@@ -91,7 +91,6 @@ class Topmega extends Topmenu
         TreeFactory $treeFactory,
         CategoryFactory $categoryFactory,
         \Magento\Cms\Model\Template\FilterProvider $filterProvider,
-        \Magento\Store\Model\StoreManagerInterface $storeManager,
         \Magento\Cms\Model\BlockFactory $blockFactory,
         Registry $registry,
         \Jnext\Megamenu\Helper\Data $dataHelper,
@@ -101,7 +100,7 @@ class Topmega extends Topmenu
         parent::__construct($context,$nodeFactory,$treeFactory, $data);
         $this->categoryFactory = $categoryFactory;
         $this->_filterProvider = $filterProvider;
-        $this->_storeManager = $storeManager;
+        $this->_storeManager = $context->getStoreManager();
         $this->_blockFactory = $blockFactory;
         $this->coreRegistry = $registry;
         $this->dataHelper = $dataHelper;
@@ -115,7 +114,6 @@ class Topmega extends Topmenu
         $this->categoryHelper = $categoryHelper;
         $this->extraClass = '';
         $this->menuType = 'default';
-        $this->storeManager = $storeManager;
         $this->currentStore = $this->storeManager->getStore();
         $this->mediaUrl = $this->currentStore->getBaseUrl(\Magento\Framework\UrlInterface::URL_TYPE_MEDIA);
         $this->categoryMediaUrl = $this->mediaUrl."catalog/category/";

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -25,11 +25,10 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
      */
     public function __construct(
         \Magento\Framework\App\Helper\Context $context,
-        CustomerSession $customerSession,
-        \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
+        CustomerSession $customerSession
     ) {
         $this->_customerSession = $customerSession;
-        $this->scopeConfig = $scopeConfig;
+        $this->scopeConfig = $context->getScopeConfig();
         parent::__construct($context);
     }
     public function allowExtension() {

--- a/composer.json
+++ b/composer.json
@@ -2,13 +2,12 @@
   "name": "jnext/megamenu",
   "description": "Jnext Megamenu for Magento 2",
   "type": "magento2-module",
-  "version": "1.0.2",
   "license": [
     "OSL-3.0",
     "AFL-3.0"
   ],
   "require": {
-    "php": "~5.5.0|~5.6.0|~7.0.0"
+    "php": "~5.5.0|~5.6.0|~7.0.0|~7.1.0|~7.2.0"
   },
   "authors": [
     {

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "jnext/megamenu",
   "description": "Jnext Megamenu for Magento 2",
   "type": "magento2-module",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": [
     "OSL-3.0",
     "AFL-3.0"

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "jnext/megamenu",
   "description": "Jnext Megamenu for Magento 2",
   "type": "magento2-module",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "license": [
     "OSL-3.0",
     "AFL-3.0"


### PR DESCRIPTION
 Errors during compilation:

 	Jnext\Megamenu\Block\Html\Topmega

 		Incorrect dependency in class Jnext\Megamenu\Block\Html\Topmega in /var/www/html/degstore/releases/20170302030550/vendor/jnext/megamenu/Block/Html/Topmega.php

 \Magento\Store\Model\StoreManagerInterface already exists in context object

 	Jnext\Megamenu\Helper\Data

 		Incorrect dependency in class Jnext\Megamenu\Helper\Data in /var/www/html/degstore/releases/20170302030550/vendor/jnext/megamenu/Helper/Data.php

 \Magento\Framework\App\Config\ScopeConfigInterface already exists in context object